### PR TITLE
Transfer and fix invoice data

### DIFF
--- a/Front-end/src/CreateBill.jsx
+++ b/Front-end/src/CreateBill.jsx
@@ -116,7 +116,7 @@ const CreateBill = ({ onBack, onGenerateInvoice }) => {
       items: items.filter(item => item.sweet && item.quantity),
       advanceAmount: Number(advanceAmount) || 0,
       discountAmount: discountAmount,
-      packageAmount: packageHandlingAmount, // Explicitly using packageHandlingAmount
+      packageHandlingAmount: packageHandlingAmount, // Fixed: using correct key name
       totalAmount: totalAmount,
       deliveryDate: deliveryDate ? deliveryDate.toISOString().split('T')[0] : '',
       deliveryTime: formattedDeliveryTime

--- a/Front-end/src/Invoice.jsx
+++ b/Front-end/src/Invoice.jsx
@@ -152,7 +152,7 @@ export const Invoice = ({ billData, onBack }) => {
   const discountAmount = typeof billData?.discountAmount === 'number' ? billData.discountAmount : Number(billData?.discountAmount) || 0;
   const totalAmount = typeof billData?.totalAmount === 'number' ? billData.totalAmount : Number(billData?.totalAmount) || 0;
   // Accept both packageAmount and packageHandlingAmount for robustness
-  const packageHandlingAmount = typeof billData?.packageHandlingAmount === 'number' ? billData.packageHandlingAmount : (typeof billData?.packageHandlingAmount === 'number' ? billData.packageHandlingAmount : Number(billData?.packageHandlingAmount) || Number(billData?.packageHandlingAmount) || 0);
+  const packageHandlingAmount = Number(billData?.packageHandlingAmount || billData?.packageAmount || 0);
   const deliveryDate = billData?.deliveryDate || '';
   // Accept both string and Date for deliveryTime
   let deliveryTime = billData?.deliveryTime || '';


### PR DESCRIPTION
Fixes Package Amount data transfer from CreateBill to Invoice and simplifies related logic in Invoice.jsx.

The Package Amount was not displaying in the invoice because `CreateBill.jsx` was sending it with the key `packageAmount`, while `Invoice.jsx` was expecting `packageHandlingAmount`. This PR corrects the key in `CreateBill.jsx` and makes `Invoice.jsx` more robust by accepting either key, ensuring the value is displayed correctly in both HTML preview and PDF download.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c7f3ca3-7f2e-4d4c-8f1f-152569f562de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c7f3ca3-7f2e-4d4c-8f1f-152569f562de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

